### PR TITLE
Use `:extra-env` in proc/process instead of `:env`

### DIFF
--- a/src/teknql/tailwind.clj
+++ b/src/teknql/tailwind.clj
@@ -76,8 +76,8 @@
        "--watch"
        "-o"
        output-path]
-      {:env {"NODE_ENV"      "development"
-             "TAILWIND_MODE" "watch"}
+      {:extra-env {"NODE_ENV"      "development"
+                   "TAILWIND_MODE" "watch"}
        :err :inherit
        :out :inheirt})
     build-state))
@@ -106,7 +106,7 @@
            tmp-dir
            "-o"
            output-path]
-          {:env {"NODE_ENV"      "production"
-                 "TAILWIND_MODE" "build"}})
+          {:extra-env {"NODE_ENV"      "production"
+                       "TAILWIND_MODE" "build"}})
         deref)
     build-state))


### PR DESCRIPTION
First, thanks for a great work! 

I've encountered an issue when trying to use the hook, it didn't start the postcss process. I've figured it's due to missing PATH from the environment in a spawned process.

`:env` [replaces] the environment completely, together with `PATH`.

This patch uses `:extra-env` instead which augments current environment
without replacing it.

[replaces]: https://github.com/babashka/process#add-environment