### PR TITLE
Use clojure println in log method

### DIFF
--- a/src/teknql/tailwind.clj
+++ b/src/teknql/tailwind.clj
@@ -36,7 +36,7 @@
   "Log the provided `strs` to stderr with a prefix determined by the build ID
   of the passed in `build-cfg`."
   [build-cfg & strs]
-  (.println *err* (apply str "[" (:build-id build-cfg) "] " strs)))
+  (println *err* (apply str "[" (:build-id build-cfg) "] " strs)))
 
 (defn- cfg-get
   "Behaves identical to `get` but logs the default value back to the user."


### PR DESCRIPTION
I got some exception at release compile.

```
Hook [0 teknql.tailwind/compile-release!] failed in stage :flush
IllegalArgumentException: No matching method println found taking 1 args for class java.io.BufferedWriter
```