### PR TITLE
Call `postcss` script with the correct ext on MS-Windows

### DIFF
--- a/src/teknql/tailwind.clj
+++ b/src/teknql/tailwind.clj
@@ -1,5 +1,6 @@
 (ns teknql.tailwind
-  (:require [jsonista.core :as j]
+  (:require [clojure.string]
+            [jsonista.core :as j]
             [cuerdas.core :as str]
             [babashka.process :as proc])
   (:import [java.nio.file Files]
@@ -13,6 +14,13 @@
    :theme    {:extend {}}
    :variants {}
    :plugins  []})
+
+(def postcss-path
+  ^{:doc "The path to the postcss command."}
+  (if (clojure.string/starts-with?
+       (System/getProperty "os.name") "Windows")
+    "./node_modules/.bin/postcss.cmd"
+    "./node_modules/.bin/postcss"))
 
 (defonce ^{:doc "Static state atom associating shadow-cljs build IDs to their respective state."}
   projects
@@ -104,7 +112,7 @@
               :tailwind/files tw-files
               :process
               (proc/process
-                ["./node_modules/.bin/postcss"
+                [postcss-path
                  (or
                   (:tailwind.css tw-files)
                   (str tmp-dir "/tailwind.css"))
@@ -140,7 +148,7 @@
                              (cfg-get config :tailwind/config nil)))]
     (log config "Generating tailwind output")
     (-> (proc/process
-          ["./node_modules/.bin/postcss"
+          [postcss-path
            (or
             (:tailwind.css tw-files)
             (str tmp-dir "/tailwind.css"))


### PR DESCRIPTION
Hi,

could you please consider a patch for `teknql.tailwind` to call the `postcss` script with the correct extension (`.cmd`) on MS-Windows.

Fixes issue #10.

Tested to work on `MS-Windows`:

```
> npx shadow-cljs watch ui
shadow-cljs - config: d:\clj\issues\issue-jit-windows\shadow-cljs.edn
shadow-cljs - socket connect failed, server process dead?
shadow-cljs - updating dependencies
shadow-cljs - dependencies updated
shadow-cljs - HTTP server available at http://localhost:3000
shadow-cljs - server version: 2.15.12 running at http://localhost:9630
shadow-cljs - nREPL server started on port 52844
shadow-cljs - watching build :ui
[:ui] Configuring build.
[:ui] Using default value for :tailwind/files.
[:ui] Using default value for :tailwind/config.
[:ui] Using default value for :postcss/config.
[:ui] Starting postcss process.
[:ui] Compiling ...

warn - You have enabled the JIT engine which is currently in preview.
warn - Preview features are not covered by semver, may introduce breaking changes, and can change at any time.

info - Tailwind CSS is watching for changes...
info - https://tailwindcss.com/docs/just-in-time-mode#watch-mode-and-one-off-builds
[:ui] Build completed. (118 files, 117 compiled, 0 warnings, 11.56s)
```
and the `site.css` file has been generated:

```
>d>dir resources\public\css\site.css
...
 Directory of D:\clj\issues\issue-jit-windows\resources\public\css

23/10/2021  21:36            14,308 site.css
```

Thanks