### PR TITLE
docs: postcss npm dependency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ JIT](https://tailwindcss.com/docs/just-in-time-mode) within Shadow Projects.
 Install the required node dependencies in your project:
 
 ```
-npm install --save-dev postcss-cli tailwindcss autoprefixer cssnano
+npm install --save-dev postcss postcss-cli tailwindcss autoprefixer cssnano
 ```
 
 Add the clojure library to your project via your preferred method (either


### PR DESCRIPTION
The postcss bin provided by postcss-cli appears to depend on the postcss
package to run.