### PR TITLE
Include a default :http-root

### DIFF
--- a/src/teknql/tailwind.clj
+++ b/src/teknql/tailwind.clj
@@ -71,7 +71,7 @@
   (let [config      (:shadow.build/config build-state)
         build-id    (:build-id config)
         out-dir     (:output-dir config)
-        http-root   (-> config :devtools :http-root)
+        http-root   (or (-> config :devtools :http-root) "resources/public")
         output-path (cfg-get config :tailwind/output "resources/public/css/site.css")
         tw-files    (cfg-get config :tailwind/files nil)
         tw-cfg      (merge default-tailwind-config


### PR DESCRIPTION
Fixes the error reported in #15 

Tested like, 

```
io.github.thejohnnybrown/shadow-cljs-tailwind-jit
        {:git/sha "aa0874ecf59b4c4f8ffc7b599dec115f81f5f4e5"}
```
in deps.edn, which resolved the error